### PR TITLE
add homework2 07.12.23

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,1 @@
+flake8 --config=./setup.cfg --ignore=WPS,DAR $1

--- a/homework/homework071223.py
+++ b/homework/homework071223.py
@@ -1,0 +1,24 @@
+"""HOMEWORK2."""
+import logging
+
+logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(levelname)s: %(message)s')
+
+# Example %-format from teacher
+norway_text = 'Automatisering akselererer %syeblikket da roboter vil erobre planeten v%sr. (%s)' % ('ø', 'å', 'Æ')
+logging.info(norway_text)
+
+norwegian_letter_ue = 'ø'
+norwegian_letter_o = 'å'
+norwegian_letter_eh = 'Æ'
+
+# Using str.format()
+norway_text_with_format_call = (
+    'Automatisering akselererer {0}yeblikket da roboter vil erobre planeten v{1}r. ({2})'
+).format(norwegian_letter_ue, norwegian_letter_o, norwegian_letter_eh)
+logging.info(norway_text_with_format_call)
+
+# Using f-string
+norway_text_with_fstring_format = (
+    f'Automatisering akselererer {norwegian_letter_ue}yeblikket da roboter vil erobre planeten v{norwegian_letter_o}r. ({norwegian_letter_eh})'
+)
+logging.info(norway_text_with_fstring_format)

--- a/homework/homework071223.py
+++ b/homework/homework071223.py
@@ -1,10 +1,16 @@
 """HOMEWORK2."""
 import logging
 
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(levelname)s: %(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s: %(message)s',
+)
 
 # Example %-format from teacher
-norway_text = 'Automatisering akselererer %syeblikket da roboter vil erobre planeten v%sr. (%s)' % ('ø', 'å', 'Æ')
+norway_text = (
+    'Automatisering akselererer %syeblikket da '
+    'roboter vil erobre planeten v%sr. (%s)' % ('ø', 'å', 'Æ')
+)
 logging.info(norway_text)
 
 norwegian_letter_ue = 'ø'
@@ -13,12 +19,15 @@ norwegian_letter_eh = 'Æ'
 
 # Using str.format()
 norway_text_with_format_call = (
-    'Automatisering akselererer {0}yeblikket da roboter vil erobre planeten v{1}r. ({2})'
+    'Automatisering akselererer {0}yeblikket da '
+    'roboter vil erobre planeten v{1}r. ({2})'
 ).format(norwegian_letter_ue, norwegian_letter_o, norwegian_letter_eh)
 logging.info(norway_text_with_format_call)
 
 # Using f-string
 norway_text_with_fstring_format = (
-    f'Automatisering akselererer {norwegian_letter_ue}yeblikket da roboter vil erobre planeten v{norwegian_letter_o}r. ({norwegian_letter_eh})'
+    f'Automatisering akselererer {norwegian_letter_ue}yeblikket da '
+    f'roboter vil erobre planeten v{norwegian_letter_o}r. '
+    f'({norwegian_letter_eh})'
 )
 logging.info(norway_text_with_fstring_format)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+min-name-length = 3
+ignore = WPS


### PR DESCRIPTION
added my homework2.

standard linter errors:
WPS323 Found `%` string formatting
E501 line too long (90 > 79 characters)
WPS323 Found `%` string formatting
E501 line too long (114 > 79 characters)
E501 line too long (89 > 79 characters)
WPS305 Found `f` string
E501 line too long (143 > 79 characters)

all other errors have been fixed.
